### PR TITLE
586: Fixing OBIE data model bug in OBSCASupportData1 invalid max length definition

### DIFF
--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBSCASupportData1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBSCASupportData1.java
@@ -73,7 +73,6 @@ public class OBSCASupportData1 {
      */
     @ApiModelProperty(value = "Specifies a character string with a maximum length of 40 characters. Usage: This field indicates whether the PSU was subject to SCA performed by the TPP")
 
-    @Size(max = 40)
     public OBAppliedAuthenticationApproachEnum getAppliedAuthenticationApproach() {
         return appliedAuthenticationApproach;
     }


### PR DESCRIPTION
Issue: https://github.com/secureapigateway/secureapigateway/issues/586
Description: Fixed invalid max length definition.